### PR TITLE
fix: add rule for js in webpack.config.js

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,6 +17,10 @@ module.exports = {
         test: /\.ts$/,
         use: ["babel-loader", "ts-loader"],
         // exclude: /node_modules/
+      },
+      {
+        test: /\.js$/,
+        use: ["babel-loader"]
       }
     ]
   },


### PR DESCRIPTION
拡張子が `.js` の場合，`babel-loader` を使うように `module.rules` に設定を追加しました．